### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,23 +109,13 @@ Contributions for improving the dashboard, enhancing customizability, and adding
     bun install
     ```
 
-2. **Change Directory:**
+2. **Install all Cargo dependencies:**
 
     ```console
-    cd src-tauri
+    cargo install --path src-tauri
     ```
 
-3. **Install all Cargo dependencies:**
-
-    ```console
-    cargo install
-    ```
-3. **Change Directory:**
-
-    ```console
-    cd ..
-    ```
-4. **Run the app in development mode:**
+3. **Run the app in development mode:**
 
     ```console
     bun run tauri dev


### PR DESCRIPTION
so this tutorial its bit changed you just need to cargo install and add the path

error: Using `cargo install` to install the binaries from the package in current working directory is no longer supported, use `cargo install --path .` instead. Use `cargo build` if you want to simply build the package.