### PR TITLE
Platform-aware downloads, compact CLI, new logo

### DIFF
--- a/website/app/[locale]/(home)/page.tsx
+++ b/website/app/[locale]/(home)/page.tsx
@@ -10,8 +10,6 @@ import { fetchGithubStats } from "@/utils/fetch-github-release";
 import { routing } from "@/i18n/routing";
 import TimerDemo from "@/components/TimerDemo";
 import Command from "@/components/Command";
-import SupportedPlatforms from "@/components/SupportedPlatforms";
-import ReleaseInfo from "@/components/ReleaseInfo";
 
 export const dynamic = "force-static";
 export const dynamicParams = false;
@@ -31,11 +29,7 @@ const RootPage = async () => {
         {/* Download & Install Group */}
         <div className="flex flex-col space-y-8 pt-16">
           <DownloadApp latestRelease={latestRelease} />
-          <Command />
-          <div className="flex flex-col space-y-4">
-            <SupportedPlatforms />
-            <ReleaseInfo tagName={tagName} totalDownloads={totalDownloads} />
-          </div>
+          <Command tagName={tagName} totalDownloads={totalDownloads} />
         </div>
 
         {/* Timer Demo */}

--- a/website/app/[locale]/download/page.tsx
+++ b/website/app/[locale]/download/page.tsx
@@ -7,17 +7,15 @@ import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { fetchGithubStats } from "@/utils/fetch-github-release";
 import Link from "next/link";
-import Image from "next/image";
 import {
-  ArrowUpRight,
   Download,
   Shield,
   Star,
-  Terminal,
   CheckCircle2,
 } from "lucide-react";
 import GradientBackground from "@/components/GradientBackground";
 import Command from "@/components/Command";
+import PlatformAwareCards from "@/components/PlatformAwareCards";
 
 export const dynamic = "force-static";
 export const dynamicParams = false;
@@ -159,21 +157,19 @@ const DownloadPage = async ({
             <div className="flex flex-wrap items-center justify-center gap-4 sm:gap-6 pt-2 text-sm text-muted-foreground">
               <span className="inline-flex items-center gap-1.5">
                 <Download className="w-4 h-4 text-[#FE4C55]" />
+                Total Downloaded:{" "}
                 <span className="font-semibold text-foreground">
-                  {totalDownloads.toLocaleString()}
-                </span>{" "}
-                downloads
-              </span>
-              <span className="hidden sm:inline w-px h-4 bg-border" />
-              <span className="inline-flex items-center gap-1.5">
-                <Star className="w-4 h-4 fill-amber-400 text-amber-400" />
-                Trusted by{" "}
-                <span className="font-semibold text-foreground">31,347+</span>{" "}
-                users
+                  {totalDownloads.toLocaleString()} times
+                </span>
               </span>
               <span className="hidden sm:inline w-px h-4 bg-border" />
               <span className="inline-flex items-center gap-1.5">
                 <Shield className="w-4 h-4 text-emerald-500" />
+                Apple Notarized
+              </span>
+              <span className="hidden sm:inline w-px h-4 bg-border" />
+              <span className="inline-flex items-center gap-1.5">
+                <Star className="w-4 h-4 fill-amber-400 text-amber-400" />
                 Open Source
               </span>
             </div>
@@ -183,75 +179,12 @@ const DownloadPage = async ({
 
       {/* ===== Platform Cards ===== */}
       <section className="w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pb-12 sm:pb-16">
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Windows */}
-          <PlatformCard
-            title="Windows"
-            icon={<WindowsIcon className="w-8 h-8" />}
-            subtitle="Windows 10 or later · 64-bit"
-            featured
-            downloads={[
-              {
-                href: downloadLinks.windowsSetup,
-                label: "Installer (EXE)",
-                tag: "Recommended",
-                primary: true,
-              },
-              {
-                href: downloadLinks.windowsMSI,
-                label: "MSI Package",
-                tag: "Enterprise",
-              },
-            ]}
-          />
-
-          {/* macOS */}
-          <PlatformCard
-            title="macOS"
-            icon={<MacIcon className="w-8 h-8" />}
-            subtitle="macOS 11 Big Sur or later"
-            downloads={[
-              {
-                href: downloadLinks.macSilicon,
-                label: "Apple Silicon",
-                tag: "M1 / M2 / M3 / M4",
-                primary: true,
-              },
-              {
-                href: downloadLinks.macIntel,
-                label: "Intel",
-                tag: "x86_64",
-              },
-            ]}
-          />
-
-          {/* Linux */}
-          <PlatformCard
-            title="Linux"
-            icon={<LinuxIcon className="w-8 h-8" />}
-            subtitle="Most modern distributions"
-            downloads={[
-              {
-                href: downloadLinks.linuxAppImage,
-                label: "AppImage",
-                tag: "Universal",
-                primary: true,
-              },
-              { href: downloadLinks.linuxDeb, label: "Debian", tag: ".deb" },
-              { href: downloadLinks.linuxRPM, label: "RPM", tag: ".rpm" },
-              {
-                href: downloadLinks.linuxTar,
-                label: "Tar.gz",
-                tag: "Archive",
-              },
-            ]}
-          />
-        </div>
+        <PlatformAwareCards downloadLinks={downloadLinks} />
       </section>
 
-      {/* ===== macOS Gatekeeper ===== */}
+      {/* ===== Apple Notarized Badge ===== */}
       <section className="w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pb-16 sm:pb-20">
-        <GatekeeperNotice />
+        <NotarizedBadge />
       </section>
 
       {/* ===== CLI Install ===== */}
@@ -269,14 +202,6 @@ const DownloadPage = async ({
         </div>
 
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-24">
-          <div className="flex flex-col items-center text-center mb-12">
-            <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full border bg-background/80 backdrop-blur-sm text-sm mb-6">
-              <Terminal className="w-4 h-4 text-[#FE4C55]" />
-              <span className="text-muted-foreground font-medium">
-                Prefer the command line?
-              </span>
-            </div>
-          </div>
           <Command />
         </div>
       </section>
@@ -327,161 +252,35 @@ export default DownloadPage;
    Sub-components
    ───────────────────────────────────────────── */
 
-interface DownloadEntry {
-  href: string | null;
-  label: string;
-  tag?: string;
-  primary?: boolean;
-}
-
-function PlatformCard({
-  title,
-  icon,
-  subtitle,
-  downloads,
-  featured,
-}: {
-  title: string;
-  icon: React.ReactNode;
-  subtitle: string;
-  downloads: DownloadEntry[];
-  featured?: boolean;
-}) {
-  const valid = downloads.filter((d) => d.href !== null);
-
+function NotarizedBadge() {
   return (
-    <div
-      className={`relative flex flex-col rounded-2xl border p-6 sm:p-8 transition-all duration-300 hover:shadow-lg ${featured
-        ? "border-[#FE4C55]/30 shadow-md shadow-[#FE4C55]/5 bg-[#FE4C55]/[0.02] dark:bg-[#FE4C55]/[0.04]"
-        : "border-border bg-card"
-        }`}
-    >
-      {featured && (
-        <span className="absolute -top-3 left-6 px-3 py-0.5 rounded-full bg-[#FE4C55] text-black text-xs font-semibold">
-          Most Popular
-        </span>
-      )}
-
-      {/* Header */}
-      <div className="flex items-center gap-4 mb-6">
-        <div
-          className={`p-3 rounded-xl ${featured
-            ? "bg-[#FE4C55]/10 text-[#FE4C55]"
-            : "bg-muted text-foreground"
-            }`}
-        >
-          {icon}
+    <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.03] dark:bg-emerald-500/[0.05] p-6 sm:p-8">
+      <div className="flex flex-col items-center text-center space-y-4">
+        <div className="p-3 rounded-xl bg-emerald-500/10">
+          <CheckCircle2 className="w-8 h-8 text-emerald-500" />
         </div>
-        <div>
-          <h3 className="text-xl font-heading font-bold">{title}</h3>
-          <p className="text-sm text-muted-foreground">{subtitle}</p>
-        </div>
-      </div>
-
-      {/* Buttons */}
-      <div className="flex flex-col gap-3 mt-auto">
-        {valid.length > 0 ? (
-          valid.map((d) => (
-            <Link
-              key={d.label}
-              href={d.href!}
-              className={`group flex items-center justify-between gap-3 px-5 py-3.5 rounded-xl text-sm font-medium transition-all duration-200 ${d.primary
-                ? "bg-[#FE4C55] text-black hover:bg-[#FE4C55]/90 hover:shadow-md hover:shadow-[#FE4C55]/20 active:scale-[0.98]"
-                : "bg-muted hover:bg-muted/80 text-foreground border border-border hover:border-foreground/10"
-                }`}
-            >
-              <span className="flex items-center gap-3">
-                <Download
-                  className={`w-4 h-4 ${d.primary ? "text-black/70" : "text-muted-foreground"
-                    }`}
-                />
-                <span className="flex flex-col items-start">
-                  <span>{d.label}</span>
-                  {d.tag && (
-                    <span
-                      className={`text-xs ${d.primary ? "text-black/50" : "text-muted-foreground"
-                        }`}
-                    >
-                      {d.tag}
-                    </span>
-                  )}
-                </span>
-              </span>
-              <ArrowUpRight
-                className={`w-4 h-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5 ${d.primary ? "text-black/50" : "text-muted-foreground"
-                  }`}
-              />
-            </Link>
-          ))
-        ) : (
-          <div className="py-8 text-center text-sm text-muted-foreground bg-muted/50 rounded-xl">
-            Downloads coming soon
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function GatekeeperNotice() {
-  return (
-    <div className="rounded-2xl border border-amber-500/20 bg-amber-500/[0.03] dark:bg-amber-500/[0.05] p-6 sm:p-8">
-      <div className="flex flex-col md:flex-row gap-8">
-        {/* Text */}
-        <div className="flex-1 space-y-4">
-          <div className="flex items-center gap-3">
-            <div className="p-2.5 rounded-xl bg-amber-500/10">
-              <Shield className="w-5 h-5 text-amber-500" />
-            </div>
-            <h3 className="font-heading font-bold text-lg">
-              macOS Gatekeeper Notice
-            </h3>
-          </div>
-
-          <p className="text-sm text-muted-foreground leading-relaxed">
-            Blink Eye is not yet notarized with Apple (requires $99/year). macOS
-            may show a security warning on first launch. To open:
+        <div className="space-y-2">
+          <h3 className="font-heading font-bold text-lg">
+            Apple Notarized
+          </h3>
+          <p className="text-sm text-muted-foreground leading-relaxed max-w-lg">
+            Blink Eye is notarized by Apple. No Gatekeeper warnings &mdash;
+            install and run directly.
           </p>
-
-          <ol className="space-y-3">
-            {[
-              <>
-                <strong className="text-foreground">Right-click</strong> the app
-                in Finder
-              </>,
-              <>
-                Select{" "}
-                <strong className="text-foreground">Open</strong> from the menu
-              </>,
-              <>
-                Click{" "}
-                <strong className="text-foreground">Open</strong> in the dialog
-              </>,
-            ].map((step, i) => (
-              <li key={i} className="flex items-start gap-3 text-sm text-muted-foreground">
-                <span className="flex items-center justify-center shrink-0 w-6 h-6 rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400 text-xs font-bold mt-0.5">
-                  {i + 1}
-                </span>
-                <span>{step}</span>
-              </li>
-            ))}
-          </ol>
         </div>
-
-        {/* Screenshot */}
-        <div className="md:w-80 lg:w-96 shrink-0">
-          <div className="relative w-full aspect-video rounded-xl overflow-hidden border bg-muted">
-            <Image
-              src="https://utfs.io/f/93hqarYp4cDdTJXpHonKyaMH6AqBZiwkW31xt0ESzPTU5Gcl"
-              alt="How to open Blink Eye on macOS"
-              fill
-              className="object-cover"
-              sizes="(max-width: 768px) 100vw, 384px"
-            />
-          </div>
-          <p className="text-xs text-muted-foreground mt-3 text-center">
-            Right-click → Open bypasses Gatekeeper
-          </p>
+        <div className="flex flex-wrap items-center justify-center gap-3 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full border bg-background/60">
+            <CheckCircle2 className="w-3.5 h-3.5 text-emerald-500" />
+            macOS Intel &amp; Apple Silicon
+          </span>
+          <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full border bg-background/60">
+            <CheckCircle2 className="w-3.5 h-3.5 text-emerald-500" />
+            Windows 10, 11
+          </span>
+          <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full border bg-background/60">
+            <CheckCircle2 className="w-3.5 h-3.5 text-emerald-500" />
+            Linux (Debian, AppImage, RPM, Tar.gz)
+          </span>
         </div>
       </div>
     </div>

--- a/website/components/Command.tsx
+++ b/website/components/Command.tsx
@@ -1,182 +1,132 @@
 // components/Command.tsx
 "use client";
 
-import React, { useState } from "react";
+import React from "react";
+import { CopyButton } from "./copy-button";
+import { MacIcon, WindowsIcon } from "@/utils/mac-win-linicon";
+import { Terminal } from "lucide-react";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { CopyButton } from "./copy-button";
-import { MacIcon, WindowsIcon } from "@/utils/mac-win-linicon";
-import { useTranslations } from "next-intl";
+import { Badge } from "@/components/ui/badge";
+import { Link } from "@/i18n/routing";
 
 interface CommandProps {
   children?: React.ReactNode;
   className?: string;
+  tagName?: string;
+  totalDownloads?: number;
 }
 
-export default function Command({ children, className = "" }: CommandProps) {
-  const [isMac, setIsMac] = useState(true);
+export default function Command({
+  children,
+  className = "",
+  tagName,
+  totalDownloads,
+}: CommandProps) {
   const macCommand =
     "brew install --cask nomandhoni-cs/blinkeye/blinkeye";
   const winCommand = "winget install NomanDhoni.BlinkEye";
-  const xattrCommand =
-    "xattr -d com.apple.quarantine '/Applications/Blink Eye.app'";
 
   return (
     <div
-      className={`w-full max-w-3xl mx-auto space-y-8 px-4 sm:px-0 font-sans ${className}`}
+      className={`w-full max-w-3xl mx-auto px-4 sm:px-0 font-sans ${className}`}
     >
-      {/* Platform Toggle */}
-      <div className="flex justify-center items-center">
-        <div className="inline-flex items-center bg-gray-100 dark:bg-[#111111] border border-gray-200 dark:border-white/10 rounded-full p-1.5 backdrop-blur-sm transition-colors duration-300">
-          <ToggleButton
-            icon={<MacIcon className="w-8 h-8 fill-current" />}
-            label="macOS"
-            isActive={isMac}
-            onClick={() => setIsMac(true)}
-          />
-          <ToggleButton
-            icon={<WindowsIcon className="w-8 h-8 fill-current" />}
-            label="Windows"
-            isActive={!isMac}
-            onClick={() => setIsMac(false)}
-          />
-        </div>
+      <div className="flex flex-col items-center text-center space-y-3">
+        {/* CLI install line */}
+        <p className="text-sm text-gray-500 dark:text-zinc-400">
+          Install using{" "}
+          <CommandPopover
+            command={macCommand}
+            label="Homebrew"
+            icon={<MacIcon className="w-3.5 h-3.5 fill-current" />}
+          />{" "}
+          on macOS or{" "}
+          <CommandPopover
+            command={winCommand}
+            label="winget"
+            icon={<WindowsIcon className="w-3.5 h-3.5 fill-current" />}
+          />{" "}
+          on Windows
+        </p>
+
+        {/* Supported platforms */}
+        <p className="text-xs text-gray-400 dark:text-zinc-500">
+          Supports macOS Intel/M Chip (ARM) | Windows 10, 11 (MSI, EXE) | Linux (Debian, AppImage, RPM, Tar.gz)
+        </p>
+
+        {/* Release info */}
+        {(tagName || totalDownloads) && (
+          <div className="flex flex-wrap items-center justify-center gap-2 text-xs text-gray-400 dark:text-zinc-500 pt-1">
+            {tagName && (
+              <Badge variant="outline">Latest: {tagName}</Badge>
+            )}
+            <span className="text-gray-300 dark:text-zinc-600">|</span>
+            <Link
+              href="/changelog"
+              className="text-gray-500 dark:text-zinc-400 hover:text-[#FE4C55] dark:hover:text-[#FE4C55] font-medium transition-colors underline underline-offset-2 decoration-gray-300 dark:decoration-zinc-600 hover:decoration-[#FE4C55]"
+            >
+              Release Notes
+            </Link>
+            <span className="text-gray-300 dark:text-zinc-600">|</span>
+            {totalDownloads != null && (
+              <Badge variant="outline">Downloaded: {totalDownloads.toLocaleString()} times</Badge>
+            )}
+          </div>
+        )}
+
+        {/* Optional children slot */}
+        {children && (
+          <div className="pt-2 animate-in fade-in slide-in-from-bottom-4 duration-700">
+            {children}
+          </div>
+        )}
       </div>
-
-      {/* Heading + macOS warning */}
-      <div className="text-center space-y-4">
-        <h2 className="text-2xl font-heading sm:text-4xl font-bold tracking-tight text-gray-900 dark:text-white transition-colors duration-300">
-          Kindly install with{" "}
-          {isMac ? "Homebrew on macOS" : "winget on Windows"}
-        </h2>
-
-        <div
-          className={`transition-all duration-500 ease-in-out ${isMac
-            ? "opacity-100 max-h-20"
-            : "opacity-0 max-h-0 overflow-hidden"
-            }`}
-        >
-          <MacOSWarning xattrCommand={xattrCommand} />
-        </div>
-      </div>
-
-      {/* Command Box */}
-      <div className="flex justify-center w-full">
-        <div className="w-full transition-all duration-300 transform">
-          <CommandBox command={isMac ? macCommand : winCommand} />
-        </div>
-      </div>
-
-      {/* Optional children slot */}
-      {children && (
-        <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-700">
-          {children}
-        </div>
-      )}
     </div>
   );
 }
 
-// --- Internal sub-components ---
-
-function ToggleButton({
-  icon,
+function CommandPopover({
+  command,
   label,
-  isActive,
-  onClick,
+  icon,
 }: {
-  icon: React.ReactNode;
+  command: string;
   label: string;
-  isActive: boolean;
-  onClick: () => void;
+  icon: React.ReactNode;
 }) {
   return (
-    <button
-      className={`flex items-center space-x-2 px-6 py-2 rounded-full transition-all duration-300 font-medium ${isActive
-        ? "bg-[#FE4C55] text-black shadow-lg shadow-red-500/20"
-        : "text-gray-800 dark:text-white hover:text-gray-900 dark:hover:text-white hover:bg-white/50 dark:hover:bg-white/5"
-        }`}
-      onClick={onClick}
-    >
-      {icon}
-      <span className="text-sm">{label}</span>
-    </button>
-  );
-}
-
-function MacOSWarning({ xattrCommand }: { xattrCommand: string }) {
-  return (
-    <div className="max-w-2xl mx-auto">
-      <p className="text-gray-600 dark:text-zinc-400 text-sm sm:text-base leading-relaxed transition-colors duration-300">
-        Blink Eye is not notarized yet, so you might encounter an error due to
-        MacOS Gatekeeper. If you face this issue, follow the{" "}
-        <Popover>
-          <PopoverTrigger>
-            <span className="cursor-pointer text-[#FE4C55] hover:text-[#ff6b73] hover:underline font-medium transition-colors">
-              Installation guide
-            </span>
-          </PopoverTrigger>
-          <PopoverContent className="w-[320px] sm:w-[400px] bg-white dark:bg-[#111111] border border-gray-200 dark:border-white/10 text-gray-800 dark:text-zinc-300 shadow-xl">
-            <h3 className="font-semibold mb-3 text-gray-900 dark:text-white text-base">
-              Bypass Gatekeeper - Installation Instructions:
-            </h3>
-            <div className="text-sm space-y-3">
-              <p>
-                <strong className="text-[#FE4C55]">Important Notice</strong>:
-                Apple requires developers to pay $100/year for app
-                notarization. As a small developer, this cost is significant,
-                so this app has not been notarized.
-              </p>
-              <p>
-                As a result, macOS Gatekeeper might block the app. You can
-                bypass this restriction using one of the following methods:
-              </p>
-              <ol className="list-decimal pl-5 space-y-2 marker:text-gray-500 dark:marker:text-zinc-500">
-                <li>
-                  <strong className="text-gray-900 dark:text-white">
-                    Via Finder:
-                  </strong>
-                  <ul className="list-disc pl-5 mt-1 space-y-1 text-gray-600 dark:text-zinc-400">
-                    <li>Right-click the app in Finder.</li>
-                    <li>Select &quot;Open&quot; to allow it to run.</li>
-                  </ul>
-                </li>
-                <li>
-                  <strong className="text-gray-900 dark:text-white">
-                    Via Terminal:
-                  </strong>
-                  <div className="mt-2 text-gray-600 dark:text-zinc-400">
-                    Run the following command to remove the Gatekeeper
-                    quarantine attribute:
-                    <div className="mt-2">
-                      <CommandBox command={xattrCommand} small />
-                    </div>
-                  </div>
-                </li>
-              </ol>
-              <p className="font-medium text-gray-900 dark:text-white mt-4 border-t border-gray-200 dark:border-white/10 pt-3">
-                Your understanding and support for independent developers like
-                me are greatly appreciated! 💡
-              </p>
-              <div className="mt-3">
-                <CommandBox command="brew install --cask nomandhoni-cs/blinkeye/blinkeye" small />
-              </div>
-              <div className="mt-3 text-sm text-gray-600 dark:text-zinc-400">
-                <p>{`==> Installing Cask blinkeye`}</p>
-                <p>{`==> Moving App 'Blink Eye.app' to '/Applications/Blink Eye.app'`}</p>
-                <p>🍺  blinkeye was successfully installed!</p>
-                <div className="mt-2">
-                  <CommandBox command="xattr -d com.apple.quarantine '/Applications/Blink Eye.app'" small />
-                </div>
-              </div>
-            </div>
-          </PopoverContent>
-        </Popover>
-      </p>
-    </div>
+    <Popover>
+      <PopoverTrigger asChild>
+        <button className="inline-flex items-center gap-1 text-[#FE4C55] hover:text-[#ff6b73] underline underline-offset-4 decoration-[#FE4C55]/40 hover:decoration-[#FE4C55] transition-colors font-medium">
+          {icon}
+          {label}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="center"
+        sideOffset={8}
+        className="w-[calc(100vw-2rem)] sm:w-[440px] rounded-2xl border shadow-2xl p-5"
+      >
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            <Terminal className="w-4 h-4 text-[#FE4C55]" />
+            <span>Run this command</span>
+          </div>
+          <div className="flex items-center justify-between gap-3 bg-muted rounded-xl px-4 py-3">
+            <code className="font-mono text-sm text-foreground overflow-x-auto whitespace-nowrap">
+              {command}
+            </code>
+            <CopyButton
+              value={command}
+              className="text-muted-foreground hover:text-foreground transition-colors shrink-0"
+            />
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/website/components/DownloadApp.tsx
+++ b/website/components/DownloadApp.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React from "react";
-import Link from "next/link";
 import Image from "next/image";
 import { DownloadIcon } from "lucide-react";
 
@@ -10,6 +9,8 @@ import DownloadDropdown from "./DownloadDropdown";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { EmptyButtonWitLink } from "./ui/EmptyButtonWitLink";
 import { getDownloadLinks } from "@/utils/getReleaseData";
+import { usePlatform } from "@/utils/usePlatform";
+import { Link } from "@/i18n/routing";
 
 export default function DownloadApp({ latestRelease }: { latestRelease?: any }) {
   const rawLinks = getDownloadLinks(latestRelease?.assets || []);
@@ -36,43 +37,98 @@ const DownloadButtons = ({
   downloadLinks,
 }: {
   downloadLinks: Record<string, string | undefined>;
-}) => (
-  /*
-   * Layout Strategy:
-   * - Mobile (default): flex-col, items-center (stacked, centered)
-   * - Desktop (lg+): flex-row, justify-center (row, centered)
-   * - Each button has w-full on mobile, w-auto on desktop
-   * - max-w-sm on mobile prevents buttons from being too wide on tablets
-   */
-  <div className="flex flex-col lg:flex-row justify-center items-center gap-4 lg:gap-5 w-full">
-    {/* WINDOWS */}
-    <DownloadOption
-      name="Windows"
-      icon={<WindowsIcon className="w-5 h-5 lg:w-6 lg:h-6 shrink-0" />}
-      mainLink={downloadLinks.windowsSetup}
-      dropdownLinks={[
-        { href: downloadLinks.windowsSetup, label: "Download (EXE)" },
-        { href: downloadLinks.windowsMSI, label: "Download (MSI)" },
-      ]}
-    />
+}) => {
+  const detected = usePlatform();
 
-    {/* MAC */}
-    <MacDownloadButton downloadLinks={downloadLinks} />
+  if (detected === "unknown") {
+    return (
+      <div className="flex flex-col lg:flex-row justify-center items-center gap-4 lg:gap-5 w-full">
+        <DownloadOption
+          name="Windows"
+          icon={<WindowsIcon className="w-5 h-5 lg:w-6 lg:h-6 shrink-0" />}
+          mainLink={downloadLinks.windowsSetup}
+          dropdownLinks={[
+            { href: downloadLinks.windowsSetup, label: "Download (EXE)" },
+            { href: downloadLinks.windowsMSI, label: "Download (MSI)" },
+          ]}
+        />
+        <MacDownloadButton downloadLinks={downloadLinks} />
+        <DownloadOption
+          name="Linux"
+          icon={<LinuxIcon className="w-5 h-5 lg:w-6 lg:h-6 shrink-0" />}
+          mainLink={downloadLinks.linuxAppImage}
+          dropdownLinks={[
+            { href: downloadLinks.linuxAppImage, label: "AppImage" },
+            { href: downloadLinks.linuxDeb, label: "Debian (.deb)" },
+            { href: downloadLinks.linuxRPM, label: "RPM (.rpm)" },
+            { href: downloadLinks.linuxTar, label: "Tar.gz" },
+          ]}
+        />
+      </div>
+    );
+  }
 
-    {/* LINUX */}
-    <DownloadOption
-      name="Linux"
-      icon={<LinuxIcon className="w-5 h-5 lg:w-6 lg:h-6 shrink-0" />}
-      mainLink={downloadLinks.linuxAppImage}
-      dropdownLinks={[
-        { href: downloadLinks.linuxAppImage, label: "AppImage" },
-        { href: downloadLinks.linuxDeb, label: "Debian (.deb)" },
-        { href: downloadLinks.linuxRPM, label: "RPM (.rpm)" },
-        { href: downloadLinks.linuxTar, label: "Tar.gz" },
-      ]}
-    />
-  </div>
-);
+  return (
+    <div className="flex flex-col items-center gap-6 w-full">
+      {/* Primary + Secondary inline */}
+      <div className="flex flex-col lg:flex-row justify-center items-center gap-4 lg:gap-5 w-full">
+        {/* Primary: detected platform shown large */}
+        {detected === "windows" && (
+          <DownloadOption
+            name="Windows"
+            icon={<WindowsIcon className="w-5 h-5 lg:w-6 lg:h-6 shrink-0" />}
+            mainLink={downloadLinks.windowsSetup}
+            dropdownLinks={[
+              { href: downloadLinks.windowsSetup, label: "Download (EXE)" },
+              { href: downloadLinks.windowsMSI, label: "Download (MSI)" },
+            ]}
+          />
+        )}
+        {detected === "mac" && (
+          <MacDownloadButton downloadLinks={downloadLinks} />
+        )}
+        {detected === "linux" && (
+          <DownloadOption
+            name="Linux"
+            icon={<LinuxIcon className="w-5 h-5 lg:w-6 lg:h-6 shrink-0" />}
+            mainLink={downloadLinks.linuxAppImage}
+            dropdownLinks={[
+              { href: downloadLinks.linuxAppImage, label: "AppImage" },
+              { href: downloadLinks.linuxDeb, label: "Debian (.deb)" },
+              { href: downloadLinks.linuxRPM, label: "RPM (.rpm)" },
+              { href: downloadLinks.linuxTar, label: "Tar.gz" },
+            ]}
+          />
+        )}
+
+        {/* Secondary: other platforms */}
+        <Link
+          href="/download"
+          className={`
+            inline-flex items-center gap-2.5 px-5 py-3.5 lg:h-16 rounded-full
+            text-sm lg:text-base font-medium text-muted-foreground
+            border border-border bg-background/60
+            hover:bg-muted hover:text-foreground hover:border-foreground/10
+            transition-colors duration-200
+          `}
+        >
+          <span className="flex items-center gap-1.5">
+            {detected !== "mac" && <MacIcon className="w-4 h-4 shrink-0" />}
+            {detected !== "mac" && detected !== "windows" && (
+              <span className="text-muted-foreground/40">/</span>
+            )}
+            {detected !== "windows" && <WindowsIcon className="w-4 h-4 shrink-0" />}
+            {detected !== "windows" && detected !== "linux" && (
+              <span className="text-muted-foreground/40">/</span>
+            )}
+            {detected !== "linux" && <LinuxIcon className="w-4 h-4 shrink-0" />}
+          </span>
+          <span>Download for other platforms</span>
+        </Link>
+      </div>
+    </div>
+  );
+};
 
 // Split-Button for Windows & Linux
 const DownloadOption = ({
@@ -198,12 +254,12 @@ const MacDownloadButton = ({
                 <strong className="text-foreground">.dmg</strong> file for your Mac.
               </li>
               <li>
-                <strong className="text-foreground">Right-Click</strong> the app and
-                select <strong className="text-foreground">Open</strong>.
+                Open the <strong className="text-foreground">.dmg</strong> file and drag
+                Blink Eye to your Applications folder.
               </li>
               <li>
-                Click <strong className="text-foreground">Open</strong> again if a
-                security warning appears.
+                Launch <strong className="text-foreground">Blink Eye</strong> from
+                Applications.
               </li>
             </ol>
 
@@ -216,11 +272,6 @@ const MacDownloadButton = ({
                 sizes="(max-width: 640px) 100vw, 480px"
               />
             </div>
-
-            <p className="text-xs text-muted-foreground">
-              * First-time users may need to right-click and select &quot;Open&quot;
-              to bypass Gatekeeper.
-            </p>
           </div>
 
           {/* Download Buttons */}

--- a/website/components/PlatformAwareCards.tsx
+++ b/website/components/PlatformAwareCards.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { Download, ArrowUpRight } from "lucide-react";
+import { LinuxIcon, MacIcon, WindowsIcon } from "@/utils/mac-win-linicon";
+import { usePlatform, type Platform } from "@/utils/usePlatform";
+
+interface DownloadEntry {
+  href: string | null;
+  label: string;
+  tag?: string;
+  primary?: boolean;
+}
+
+interface PlatformConfig {
+  key: Platform;
+  title: string;
+  icon: React.ReactNode;
+  subtitle: string;
+  downloads: DownloadEntry[];
+}
+
+const PLATFORM_ORDER: Platform[] = ["windows", "mac", "linux"];
+
+export default function PlatformAwareCards({
+  downloadLinks,
+}: {
+  downloadLinks: { [key: string]: string | null };
+}) {
+  const detected = usePlatform();
+
+  const platforms: PlatformConfig[] = [
+    {
+      key: "windows",
+      title: "Windows",
+      icon: <WindowsIcon className="w-8 h-8" />,
+      subtitle: "Windows 10 or later · 64-bit",
+      downloads: [
+        {
+          href: downloadLinks.windowsSetup,
+          label: "Installer (EXE)",
+          tag: "Recommended",
+          primary: true,
+        },
+        {
+          href: downloadLinks.windowsMSI,
+          label: "MSI Package",
+          tag: "Enterprise",
+        },
+      ],
+    },
+    {
+      key: "mac",
+      title: "macOS",
+      icon: <MacIcon className="w-8 h-8" />,
+      subtitle: "macOS 11 Big Sur or later",
+      downloads: [
+        {
+          href: downloadLinks.macSilicon,
+          label: "Apple Silicon",
+          tag: "M1 / M2 / M3 / M4",
+          primary: true,
+        },
+        {
+          href: downloadLinks.macIntel,
+          label: "Intel",
+          tag: "x86_64",
+        },
+      ],
+    },
+    {
+      key: "linux",
+      title: "Linux",
+      icon: <LinuxIcon className="w-8 h-8" />,
+      subtitle: "Most modern distributions",
+      downloads: [
+        {
+          href: downloadLinks.linuxAppImage,
+          label: "AppImage",
+          tag: "Universal",
+          primary: true,
+        },
+        { href: downloadLinks.linuxDeb, label: "Debian", tag: ".deb" },
+        { href: downloadLinks.linuxRPM, label: "RPM", tag: ".rpm" },
+        {
+          href: downloadLinks.linuxTar,
+          label: "Tar.gz",
+          tag: "Archive",
+        },
+      ],
+    },
+  ];
+
+  const ordered =
+    detected !== "unknown"
+      ? [...platforms].sort((a, b) => {
+          if (a.key === detected) return -1;
+          if (b.key === detected) return 1;
+          return 0;
+        })
+      : platforms;
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      {ordered.map((p) => (
+        <PlatformCard
+          key={p.key}
+          title={p.title}
+          icon={p.icon}
+          subtitle={p.subtitle}
+          downloads={p.downloads}
+          featured={detected !== "unknown" && p.key === detected}
+        />
+      ))}
+    </div>
+  );
+}
+
+function PlatformCard({
+  title,
+  icon,
+  subtitle,
+  downloads,
+  featured,
+}: {
+  title: string;
+  icon: React.ReactNode;
+  subtitle: string;
+  downloads: DownloadEntry[];
+  featured?: boolean;
+}) {
+  const valid = downloads.filter((d) => d.href !== null);
+
+  return (
+    <div
+      className={`relative flex flex-col rounded-2xl border p-6 sm:p-8 transition-all duration-300 hover:shadow-lg ${
+        featured
+          ? "border-[#FE4C55]/30 shadow-md shadow-[#FE4C55]/5 bg-[#FE4C55]/[0.02] dark:bg-[#FE4C55]/[0.04]"
+          : "border-border bg-card"
+      }`}
+    >
+      {featured && (
+        <span className="absolute -top-3 left-6 px-3 py-0.5 rounded-full bg-[#FE4C55] text-black text-xs font-semibold">
+          Your Platform
+        </span>
+      )}
+
+      {/* Header */}
+      <div className="flex items-center gap-4 mb-6">
+        <div
+          className={`p-3 rounded-xl ${
+            featured
+              ? "bg-[#FE4C55]/10 text-[#FE4C55]"
+              : "bg-muted text-foreground"
+          }`}
+        >
+          {icon}
+        </div>
+        <div>
+          <h3 className="text-xl font-heading font-bold">{title}</h3>
+          <p className="text-sm text-muted-foreground">{subtitle}</p>
+        </div>
+      </div>
+
+      {/* Buttons */}
+      <div className="flex flex-col gap-3 mt-auto">
+        {valid.length > 0 ? (
+          valid.map((d) => (
+            <Link
+              key={d.label}
+              href={d.href!}
+              className={`group flex items-center justify-between gap-3 px-5 py-3.5 rounded-xl text-sm font-medium transition-all duration-200 ${
+                d.primary
+                  ? "bg-[#FE4C55] text-black hover:bg-[#FE4C55]/90 hover:shadow-md hover:shadow-[#FE4C55]/20 active:scale-[0.98]"
+                  : "bg-muted hover:bg-muted/80 text-foreground border border-border hover:border-foreground/10"
+              }`}
+            >
+              <span className="flex items-center gap-3">
+                <Download
+                  className={`w-4 h-4 ${
+                    d.primary ? "text-black/70" : "text-muted-foreground"
+                  }`}
+                />
+                <span className="flex flex-col items-start">
+                  <span>{d.label}</span>
+                  {d.tag && (
+                    <span
+                      className={`text-xs ${
+                        d.primary ? "text-black/50" : "text-muted-foreground"
+                      }`}
+                    >
+                      {d.tag}
+                    </span>
+                  )}
+                </span>
+              </span>
+              <ArrowUpRight
+                className={`w-4 h-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5 ${
+                  d.primary ? "text-black/50" : "text-muted-foreground"
+                }`}
+              />
+            </Link>
+          ))
+        ) : (
+          <div className="py-8 text-center text-sm text-muted-foreground bg-muted/50 rounded-xl">
+            Downloads coming soon
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/website/components/layout/header.tsx
+++ b/website/components/layout/header.tsx
@@ -2,7 +2,7 @@
 
 import { CONFIG } from "@/configs/site";
 import Link from "next/link";
-import logo from "../../public/logo.png";
+import newLogo from "../../public/newlogo.svg";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "../ui/button";
 import Image from "next/image";
@@ -35,9 +35,9 @@ export const Header = () => {
         `}
       >
         {/* Logo Section */}
-        <Link href={`/${locale}`} className="flex items-center space-x-3">
-          <Image src={logo} alt="Blink Eye Logo" height={32} width={32} />
-          <span className="font-heading text-xl">Blink Eye</span>
+        <Link href={`/${locale}`} className="flex items-center space-x-2">
+          <Image src={newLogo} alt="Blink Eye Logo" height={28} width={28} />
+          <span className="font-heading text-lg">blinkeye</span>
         </Link>
 
         {/* Navigation Links */}
@@ -82,10 +82,10 @@ export const Header = () => {
           <div className="flex items-center space-x-4 bg-background/30 backdrop-blur-md rounded-full px-4 py-2 motion-preset-expand motion-duration-1000">
             <Link href={`/${locale}`}>
               <Image
-                src={logo}
+                src={newLogo}
                 alt="Blink Eye Logo"
-                height={32}
-                width={32}
+                height={24}
+                width={24}
                 className="mr-2"
               />
             </Link>

--- a/website/messages/en.json
+++ b/website/messages/en.json
@@ -129,7 +129,7 @@
     "institute": "American Academy of Ophthalmology"
   },
   "DownloadApp": {
-    "supportedPlatforms": "Supports macOS Intel/M Chip (ARM) | Windows 10, 11 (MSI, EXE) | Linux (Debian, AppImage, RPM, TAR)"
+    "supportedPlatforms": "Supports macOS Intel/M Chip (ARM) | Windows 10, 11 (MSI, EXE) | Linux (Debian, AppImage, RPM, Tar.gz)"
   },
   "FeatureGrid": {
     "featureTitle": "Features",

--- a/website/utils/usePlatform.ts
+++ b/website/utils/usePlatform.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export type Platform = "mac" | "windows" | "linux" | "unknown";
+
+export function usePlatform(): Platform {
+  const [platform, setPlatform] = useState<Platform>("unknown");
+
+  useEffect(() => {
+    const ua = navigator.userAgent.toLowerCase();
+    const plat = navigator.platform?.toLowerCase() || "";
+
+    if (plat.includes("mac") || ua.includes("mac")) {
+      setPlatform("mac");
+    } else if (plat.includes("win") || ua.includes("win")) {
+      setPlatform("windows");
+    } else if (plat.includes("linux") || ua.includes("linux")) {
+      setPlatform("linux");
+    } else {
+      setPlatform("unknown");
+    }
+  }, []);
+
+  return platform;
+}


### PR DESCRIPTION
## Changes

### Website
- Platform-aware download buttons: Detect user OS and show matching download button prominently, with inline "Download for other platforms" link showing other OS icons
- Compact CLI section: Merged Command, SupportedPlatforms, and ReleaseInfo into a single compact line
- Apple Notarized badge: Replaced Gatekeeper warning with notarized badge on download page
- shadcn Badge: Version and download count now use default Badge component
- New logo: Swapped to newlogo.svg with lowercase "blinkeye" in header
- Removed Gatekeeper warnings from macOS popover and CLI section

### Other
- Homebrew cask updater workflow
- Theme system, sidebar redesign, onboarding improvements
